### PR TITLE
set up GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install SDL2 dependencies
+      run: sudo apt-get install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-gfx-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install SDL2 dependencies
-      run: sudo apt-get install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-gfx-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-gfx-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ 'main' ]
+  pull_request:
+    branches: [ '**' ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
CI script will build the program (and run tests, when we write them) upon pull requests to any branch and upon push to main. Takes about a minute and a half.

On PRs, GitHub should show an error message if the build would fail following merge. For all runs, there will be logs in the Actions tab on the repository.

There are some changes we can make to cargo.toml to have it also fail on warnings, e.g. for not using snake_case like Dr. Farnan talked about. See https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md#alternatives. I'm not including that in this PR so that we can take some time to evaluate how this works for us.