### PR TITLE
CI: install latest stable Rust version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,8 +16,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Ensure latest Rust
-      run: sudo rustup update
+    - name: Install latest stable Rust version
+      uses: actions-rs/rust-toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        default: true
+        override: true
     - name: Install SDL2 dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install latest stable Rust version
-      uses: actions-rs/rust-toolchain@v1
+      uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Ensure latest Rust
+      run: sudo rustup update
     - name: Install SDL2 dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
This PR updates the CI script to install the latest stable Rust version, instead of using whatever old default version the runners come with. This should fix the status on my animation PR, which currently fails because it uses a constant that wasn't stabilized until Rust 1.53.0, released a couple weeks ago.