### PR TITLE
style, formatting, warnings fixes; stronger errors and CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,9 +11,8 @@ env:
 
 jobs:
   build:
-
+    name: Build and test
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Install latest stable Rust version
@@ -31,3 +30,20 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+  fmt:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        default: true
+        override: true
+    - run: rustup component add rustfmt
+    - uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check

--- a/src/anim.rs
+++ b/src/anim.rs
@@ -86,7 +86,7 @@ impl<T> Animation<T> {
 
     /// Advances a number of frames regardless of time. The last frame time
     /// advances by the equivalent of n frames.
-    pub fn advance(&mut self, n: usize) -> &T {
+    fn advance(&mut self, n: usize) -> &T {
         if self.freezes && self.k + n >= self.frames.len() {
             return self.advance(self.frames.len() - self.k - 1);
         }
@@ -99,7 +99,7 @@ impl<T> Animation<T> {
     }
 
     /// Moves to the next frame regardless of time.
-    pub fn next(&mut self) -> &T {
+    fn next(&mut self) -> &T {
         self.advance(1)
     }
 

--- a/src/anim.rs
+++ b/src/anim.rs
@@ -86,6 +86,7 @@ impl<T> Animation<T> {
 
     /// Advances a number of frames regardless of time. The last frame time
     /// advances by the equivalent of n frames.
+    #[allow(dead_code)]
     fn advance(&mut self, n: usize) -> &T {
         if self.freezes && self.k + n >= self.frames.len() {
             return self.advance(self.frames.len() - self.k - 1);
@@ -99,6 +100,7 @@ impl<T> Animation<T> {
     }
 
     /// Moves to the next frame regardless of time.
+    #[allow(dead_code)]
     fn next(&mut self) -> &T {
         self.advance(1)
     }

--- a/src/crop.rs
+++ b/src/crop.rs
@@ -44,6 +44,7 @@ pub struct Crop<'a> {
 
     genes: Option<genes::Genes>,
 
+    #[allow(dead_code)]
     pollinated: bool,
 }
 

--- a/src/crop.rs
+++ b/src/crop.rs
@@ -4,8 +4,8 @@ use sdl2::render::{Texture, WindowCanvas};
 use std::str::FromStr;
 
 use crate::genes;
-use crate::inventory_item_trait;
 use crate::population::Population;
+use crate::InventoryItemTrait;
 
 // Import constant from main
 use crate::{CAM_H, CAM_W, TILE_SIZE};
@@ -311,7 +311,7 @@ impl<'a> Crop<'a> {
     }
 }
 
-impl inventory_item_trait for Crop<'_> {
+impl InventoryItemTrait for Crop<'_> {
     /// Sort inventory so that you take the best item from the inventory
     /// This can be a combination of factors
     /// i.e. 2*speed + resistance

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -247,7 +247,7 @@ impl<'a> Inventory<'a> {
     /// Add item into the correct inventory slot
     /// Right now the correct slot is hard coded
     pub fn add_item(&mut self, new_crop: Crop<'a>) {
-        if (new_crop.get_stage() == 3) {
+        if new_crop.get_stage() == 3 {
             let inventory_slot_index = match new_crop.get_crop_type_enum() {
                 CropType::Carrot => 4,
                 CropType::Corn => 6,
@@ -273,7 +273,7 @@ impl<'a> Inventory<'a> {
     pub fn use_inventory(
         &mut self,
         square: (i32, i32),
-        mut pop: &mut Population,
+        pop: &mut Population,
     ) -> Option<(Option<CropType>, Option<genes::Genes>)> {
         let current_item = self.inventory_slots[self.selected as usize].get_item(0);
         match current_item {

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -240,6 +240,7 @@ impl<'a> Inventory<'a> {
         self.selected = _selected
     }
 
+    #[allow(dead_code)]
     pub fn get_selected(&self) -> i32 {
         self.selected
     }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -5,9 +5,9 @@ use sdl2::render::WindowCanvas;
 use crate::crop::Crop;
 use crate::crop::CropType;
 use crate::genes;
-use crate::inventory_item_trait;
 use crate::population::Population;
 use crate::tool::Tool;
+use crate::InventoryItemTrait;
 
 use sdl2::image::LoadTexture;
 use sdl2::render::TextureCreator;
@@ -27,16 +27,16 @@ static NUMBER_SIZE: i32 = 20;
 /// Inventory slots are sorted, so you have the "best" seed at the bottom of the queue
 /// This is done so that seed can have different genetics, but still have one inventory slot
 /// The vectors are sorted by their value: a number that is determined in the crop class
-struct Inventory_Item<'a> {
-    items: Vec<Box<dyn inventory_item_trait + 'a>>,
+struct InventoryItem<'a> {
+    items: Vec<Box<dyn InventoryItemTrait + 'a>>,
     is_tool: bool,
 }
 
-impl<'a> Inventory_Item<'a> {
+impl<'a> InventoryItem<'a> {
     /// Takes in is_tool: used to differentiate tools from crops
     /// and initializes vector of inventory_item_trait
-    pub fn new(is_tool: bool) -> Inventory_Item<'a> {
-        Inventory_Item {
+    pub fn new(is_tool: bool) -> InventoryItem<'a> {
+        InventoryItem {
             items: Vec::new(),
             is_tool,
         }
@@ -49,7 +49,7 @@ impl<'a> Inventory_Item<'a> {
     /// Insert item into sorted vector
     /// Right now its just insertion sort
     /// Might change to a more efficient insertion if there is time
-    pub fn add_item(&mut self, new_item: Box<dyn inventory_item_trait + 'a>) {
+    pub fn add_item(&mut self, new_item: Box<dyn InventoryItemTrait + 'a>) {
         let mut i = 0;
         let mut insert_pos = self.get_len() as usize;
         for item in &self.items {
@@ -63,11 +63,11 @@ impl<'a> Inventory_Item<'a> {
     }
 
     /// This will pop the highest sorted item at index 0
-    pub fn pop_item(&mut self) -> Box<dyn inventory_item_trait + 'a> {
+    pub fn pop_item(&mut self) -> Box<dyn InventoryItemTrait + 'a> {
         self.items.remove(0 as usize)
     }
 
-    pub fn get_item(&self, index: i32) -> Option<&Box<dyn inventory_item_trait + 'a>> {
+    pub fn get_item(&self, index: i32) -> Option<&Box<dyn InventoryItemTrait + 'a>> {
         if index >= self.get_len() {
             return None;
         }
@@ -79,7 +79,7 @@ impl<'a> Inventory_Item<'a> {
 /// Also keeps track of the current selected inventory slot
 /// squares is used to draw the inventory slot. It is kept here so that it doesn't have to be initialized each time you want to draw
 pub struct Inventory<'a> {
-    inventory_slots: Vec<Inventory_Item<'a>>,
+    inventory_slots: Vec<InventoryItem<'a>>,
     selected: i32,
     squares: Vec<Rect>,
 }
@@ -88,8 +88,8 @@ pub struct Inventory<'a> {
 impl<'a> Inventory<'a> {
     pub fn new(texture_creator: &'a TextureCreator<WindowContext>) -> Inventory<'a> {
         // Initializes inventory slots and sets tool slots to true
-        let mut inventory_slots: Vec<Inventory_Item> =
-            (0..10).map(|x| Inventory_Item::new(x < 3)).collect();
+        let mut inventory_slots: Vec<InventoryItem> =
+            (0..10).map(|x| InventoryItem::new(x < 3)).collect();
 
         // Add tool slots into the inventory
         inventory_slots[0].add_item(Box::new(Tool::new(
@@ -97,7 +97,7 @@ impl<'a> Inventory<'a> {
             texture_creator
                 .load_texture("src/images/itemMenu.png")
                 .unwrap(),
-            crate::tool::tool_type::hand,
+            crate::tool::ToolType::Hand,
         )));
 
         inventory_slots[1].add_item(Box::new(Tool::new(
@@ -105,7 +105,7 @@ impl<'a> Inventory<'a> {
             texture_creator
                 .load_texture("src/images/itemMenu.png")
                 .unwrap(),
-            crate::tool::tool_type::hoe,
+            crate::tool::ToolType::Hoe,
         )));
 
         inventory_slots[2].add_item(Box::new(Tool::new(
@@ -113,7 +113,7 @@ impl<'a> Inventory<'a> {
             texture_creator
                 .load_texture("src/images/itemMenu.png")
                 .unwrap(),
-            crate::tool::tool_type::watering_can,
+            crate::tool::ToolType::WateringCan,
         )));
 
         let temp_select = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,14 +26,12 @@ use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 use sdl2::render::BlendMode;
 use sdl2::render::Texture;
-use sdl2::render::TextureCreator;
-use sdl2::render::WindowCanvas;
 use std::collections::HashSet;
 use std::thread;
 use std::time::Duration;
 
 use crate::crop::CropType;
-use crate::market_item::Market_item;
+use crate::market_item::MarketItem;
 use crate::player::{PLAYER_HEIGHT, PLAYER_WIDTH};
 
 const VSYNC: bool = true;
@@ -60,7 +58,7 @@ pub enum Area {
 }
 
 /// Trait used for items that can exist inside of the inventory
-pub trait inventory_item_trait {
+pub trait InventoryItemTrait {
     /// Return some determined value to sort the inventory
     fn get_value(&self) -> i32;
     // Get the texture
@@ -183,10 +181,10 @@ fn main() {
     let _seed_textures = texture_creator
         .load_texture("src/images/Crop_Tileset.png")
         .unwrap();
-    let store_item_0 = Market_item::new(0, 10, 3, Rect::new(0, 0, 80, 80), CropType::Carrot);
-    let store_item_1 = Market_item::new(7, 12, 2, Rect::new(0, 80, 80, 80), CropType::Corn);
-    let store_item_2 = Market_item::new(14, 11, 4, Rect::new(0, 160, 80, 80), CropType::Lettuce);
-    let store_item_3 = Market_item::new(21, 15, 6, Rect::new(0, 240, 80, 80), CropType::Potato);
+    let store_item_0 = MarketItem::new(0, 10, 3, Rect::new(0, 0, 80, 80), CropType::Carrot);
+    let store_item_1 = MarketItem::new(7, 12, 2, Rect::new(0, 80, 80, 80), CropType::Corn);
+    let store_item_2 = MarketItem::new(14, 11, 4, Rect::new(0, 160, 80, 80), CropType::Lettuce);
+    let store_item_3 = MarketItem::new(21, 15, 6, Rect::new(0, 240, 80, 80), CropType::Potato);
 
     let mut market_items = vec![store_item_0, store_item_1, store_item_2, store_item_3];
 
@@ -542,60 +540,4 @@ fn main() {
 
         wincan.present();
     } // end gameloop
-}
-
-/**
- * Method to display team creditsF
- */
-fn roll_credits<T>(
-    window: &mut WindowCanvas,
-    tc: &TextureCreator<T>,
-    r: Rect,
-) -> Result<(), String> {
-    // paths for group images
-    let img1 = "src/images/credits/jaysonCredits.png";
-    let img2 = "src/images/credits/JackMCredits.png";
-    let img3 = "src/images/credits/natCredits.png";
-    let img4 = "src/images/credits/jacobCredits.png";
-    let img5 = "src/images/credits/wesleyCredits.png";
-    let img6 = "src/images/credits/jackACredits.png";
-    let img7 = "src/images/credits/brandenCredits.png";
-    let images = [img1, img2, img3, img4, img5, img6, img7];
-
-    // Iterate through images; fade in and out
-    for img in 0..images.len() {
-        let _ = fade(window, tc.load_texture(images[img]).unwrap(), r);
-    }
-
-    Ok(())
-}
-
-// method to fade in and out
-fn fade(window: &mut WindowCanvas, ms: Texture, r: Rect) -> Result<(), String> {
-    // fade in
-    let mut i = 0;
-    while i < 254 {
-        window.clear();
-        window.copy(&ms, None, None)?;
-        window.set_draw_color(Color::RGBA(255, 255, 255, 255 - i));
-        window.fill_rect(r)?;
-        window.present();
-        thread::sleep(Duration::from_millis(1));
-        i = i + 2;
-    }
-
-    thread::sleep(Duration::from_secs(1));
-
-    // fade out
-    i = 0;
-    while i < 254 {
-        window.clear();
-        window.copy(&ms, None, None)?;
-        window.set_draw_color(Color::RGBA(255, 255, 255, i));
-        window.fill_rect(r)?;
-        window.present();
-        thread::sleep(Duration::from_millis(1));
-        i = i + 2;
-    }
-    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,11 +17,11 @@ mod tile;
 mod tool;
 
 use anim::Animation;
-use item::Item;
+
 use sdl2::event::Event;
 use sdl2::image::LoadTexture;
 use sdl2::keyboard::Keycode;
-use sdl2::mouse::MouseButton;
+
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 use sdl2::render::BlendMode;
@@ -31,14 +31,10 @@ use sdl2::render::WindowCanvas;
 use std::collections::HashSet;
 use std::thread;
 use std::time::Duration;
-use std::time::Instant;
 
 use crate::crop::CropType;
 use crate::market_item::Market_item;
-use crate::player::{Direction, PLAYER_HEIGHT, PLAYER_WIDTH};
-
-use std::fs::File;
-use std::io::{Read, Write};
+use crate::player::{PLAYER_HEIGHT, PLAYER_WIDTH};
 
 const VSYNC: bool = true;
 // Camera dimensions
@@ -106,7 +102,7 @@ fn main() {
     wincan.set_draw_color(Color::RGBA(255, 255, 255, 255));
     wincan.clear();
 
-    let crop_texture = texture_creator
+    let _crop_texture = texture_creator
         .load_texture("src/images/Crop_Tileset.png")
         .unwrap();
 
@@ -115,10 +111,10 @@ fn main() {
     // roll_credits(&mut wincan, &texture_creator, r).unwrap();
 
     let mut event_pump = sdl_cxt.event_pump().unwrap();
-    let mut x_vel = 0;
-    let mut y_vel = 0;
+    let _x_vel = 0;
+    let _y_vel = 0;
 
-    let mut menu_location = 0;
+    let _menu_location = 0;
 
     let mut p = player::Player::new(
         Rect::new(
@@ -173,18 +169,18 @@ fn main() {
 
     // REMOVE LATER ^^
 
-    let mut crop_vec: Vec<crop::Crop> = Vec::new();
+    let _crop_vec: Vec<crop::Crop> = Vec::new();
 
     let home_tup = save_load::load_home(&texture_creator);
     let mut pop = home_tup.0;
-    let mut item_vec = home_tup.1;
+    let item_vec = home_tup.1;
 
     let market_tup = save_load::load_market(&texture_creator);
-    let mut m_pop = market_tup.0;
-    let mut m_item_vec = market_tup.1;
+    let m_pop = market_tup.0;
+    let m_item_vec = market_tup.1;
 
     // create a store with temp items
-    let mut seed_textures = texture_creator
+    let _seed_textures = texture_creator
         .load_texture("src/images/Crop_Tileset.png")
         .unwrap();
     let store_item_0 = Market_item::new(0, 10, 3, Rect::new(0, 0, 80, 80), CropType::Carrot);
@@ -198,7 +194,7 @@ fn main() {
 
     let mut in_area = Area::Home;
     // Things that might be used every frame but should only be loaded once:
-    let bg_tiles_tex = texture_creator
+    let _bg_tiles_tex = texture_creator
         .load_texture("src/images/Background_Tileset.png")
         .unwrap();
 
@@ -390,7 +386,7 @@ fn main() {
                     thread::sleep(Duration::from_millis(160));
                 }
                 if keystate.contains(&Keycode::P) {
-                    let new_crop_texture = texture_creator
+                    let _new_crop_texture = texture_creator
                         .load_texture("src/images/Crop_Tileset.png")
                         .unwrap();
                     store.confirm_purchase();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(nonstandard_style, unused_parens)]
+
 extern crate sdl2;
 
 // Modules

--- a/src/market.rs
+++ b/src/market.rs
@@ -6,17 +6,15 @@ use crate::TILE_SIZE;
 use crate::{crop, item, population, save_load, tile, Animation, CAM_H, CAM_W};
 
 use crate::player::Player;
-use sdl2::event::Event;
+
 use sdl2::image::LoadTexture;
 use sdl2::keyboard::Keycode;
-use sdl2::mouse::MouseButton;
+
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
-use sdl2::render::BlendMode;
-use sdl2::render::Texture;
-use sdl2::render::TextureCreator;
+
 use sdl2::render::WindowCanvas;
-use sdl2::video::WindowContext;
+
 use std::collections::HashSet;
 use std::thread;
 use std::time::Duration;
@@ -28,7 +26,7 @@ pub fn start_market_transition_menu<'a>(
     wincan: &mut WindowCanvas,
     keystate: HashSet<Keycode>,
     r: Rect,
-    mut in_area: Option<Area>,
+    in_area: Option<Area>,
 ) -> (Option<Menu>, Area) {
     let texture_creator = wincan.texture_creator();
 

--- a/src/market.rs
+++ b/src/market.rs
@@ -3,7 +3,7 @@ use crate::Menu;
 use crate::BG_H;
 use crate::BG_W;
 use crate::TILE_SIZE;
-use crate::{crop, item, population, save_load, tile, Animation, CAM_H, CAM_W};
+use crate::{item, population, Animation, CAM_H, CAM_W};
 
 use crate::player::Player;
 

--- a/src/market_item.rs
+++ b/src/market_item.rs
@@ -1,10 +1,6 @@
 use crate::crop::CropType;
-use sdl2::image::LoadTexture;
-use sdl2::pixels::Color;
+
 use sdl2::rect::Rect;
-use sdl2::render::Texture;
-use sdl2::render::TextureCreator;
-use sdl2::render::WindowCanvas;
 
 /*OFFSETS FOR REFERENCE*/
 // SEED 1 - 0

--- a/src/market_item.rs
+++ b/src/market_item.rs
@@ -8,7 +8,7 @@ use sdl2::rect::Rect;
 // SEED 3 -
 // SEED 4 -
 
-pub struct Market_item {
+pub struct MarketItem {
     pub item_label_offset: i32,
     pub amount: i32,
     pub price: i32,
@@ -17,15 +17,15 @@ pub struct Market_item {
     // texture: Texture,
 }
 
-impl Market_item {
+impl MarketItem {
     pub fn new(
         item_label_offset: i32,
         amount: i32,
         price: i32,
         pos: Rect,
         crop: CropType, /*, texture: Texture */
-    ) -> Market_item {
-        Market_item {
+    ) -> MarketItem {
+        MarketItem {
             item_label_offset,
             amount,
             price,

--- a/src/player.rs
+++ b/src/player.rs
@@ -4,7 +4,7 @@
 use std::time::{Duration, Instant};
 
 // Imports
-use sdl2::image::LoadTexture;
+
 use sdl2::rect::Rect;
 use sdl2::render::Texture;
 use sdl2::render::TextureCreator;
@@ -16,7 +16,7 @@ use crate::crop::Crop;
 use crate::crop::CropType;
 use crate::genes;
 use crate::inventory::Inventory;
-use crate::item::Item;
+
 use crate::population::Population;
 
 // Player sprites are 54x90 px.
@@ -157,7 +157,7 @@ impl<'a> Player<'a> {
     pub fn use_inventory(
         &mut self,
         square: (i32, i32),
-        mut pop: &mut Population,
+        pop: &mut Population,
     ) -> Option<(Option<CropType>, Option<genes::Genes>)> {
         self.inventory.use_inventory(square, pop)
         /*match return_crop{

--- a/src/player.rs
+++ b/src/player.rs
@@ -107,21 +107,25 @@ impl<'a> Player<'a> {
     }
 
     /// Get left bound of player
+    #[allow(dead_code)]
     pub fn left(&self) -> i32 {
         self.pos.left()
     }
 
     /// Get right bound of player
+    #[allow(dead_code)]
     pub fn right(&self) -> i32 {
         self.pos.right()
     }
 
     /// Get top bound of player
+    #[allow(dead_code)]
     pub fn top(&self) -> i32 {
         self.pos.top()
     }
 
     /// Get bottom bound of player
+    #[allow(dead_code)]
     pub fn bottom(&self) -> i32 {
         self.pos.bottom()
     }
@@ -150,6 +154,7 @@ impl<'a> Player<'a> {
         self.inventory.set_selected(_selected);
     }
 
+    #[allow(dead_code)]
     pub fn get_selected(&self) -> i32 {
         self.inventory.get_selected()
     }
@@ -296,6 +301,7 @@ impl<'a> Player<'a> {
             || a.left() > b.right())
     }
 
+    #[allow(dead_code)]
     pub fn get_inventory(&mut self) -> &mut Inventory<'a> {
         &mut self.inventory
     }

--- a/src/population.rs
+++ b/src/population.rs
@@ -3,36 +3,36 @@ use crate::tile::Tile;
 use crate::TILE_SIZE;
 
 //Struct used to combine tile and crop structs into one for easy storage into the vector
-pub struct Crop_Tile<'a> {
+pub struct CropTile<'a> {
     pub tile: Tile<'a>,
     pub crop: Crop<'a>,
 }
 
-impl<'a> Crop_Tile<'a> {
-    pub fn new(tile: Tile<'a>, crop: Crop<'a>) -> Crop_Tile<'a> {
-        Crop_Tile { tile, crop }
+impl<'a> CropTile<'a> {
+    pub fn new(tile: Tile<'a>, crop: Crop<'a>) -> CropTile<'a> {
+        CropTile { tile, crop }
     }
 
-    pub fn setCrop(&mut self, c: Crop<'a>) {
+    pub fn set_crop(&mut self, c: Crop<'a>) {
         self.crop = c;
     }
 }
 
 pub struct Population<'a> {
-    crop_tile_vec: Vec<Vec<Crop_Tile<'a>>>,
+    crop_tile_vec: Vec<Vec<CropTile<'a>>>,
 }
 
 impl<'a> Population<'a> {
-    pub fn new(crop_tile_vec: Vec<Vec<Crop_Tile<'a>>>) -> Population<'a> {
+    pub fn new(crop_tile_vec: Vec<Vec<CropTile<'a>>>) -> Population<'a> {
         Population { crop_tile_vec }
     }
 
     //Lends out the whole vector
-    pub fn get_vec(&self) -> &Vec<Vec<Crop_Tile>> {
+    pub fn get_vec(&self) -> &Vec<Vec<CropTile>> {
         &self.crop_tile_vec
     }
 
-    pub fn get_vec_mut(&mut self) -> &mut Vec<Vec<Crop_Tile<'a>>> {
+    pub fn get_vec_mut(&mut self) -> &mut Vec<Vec<CropTile<'a>>> {
         &mut self.crop_tile_vec
     }
 

--- a/src/population.rs
+++ b/src/population.rs
@@ -1,8 +1,6 @@
 use crate::crop::Crop;
 use crate::tile::Tile;
-use crate::{CAM_H, CAM_W, TILE_SIZE};
-use sdl2::rect::Rect;
-use sdl2::render::{Texture, WindowCanvas};
+use crate::TILE_SIZE;
 
 //Struct used to combine tile and crop structs into one for easy storage into the vector
 pub struct Crop_Tile<'a> {

--- a/src/save_load.rs
+++ b/src/save_load.rs
@@ -1,7 +1,7 @@
 use crate::{crop, item, population, tile, BG_H, BG_W, TILE_SIZE};
 use sdl2::image::LoadTexture;
 use sdl2::rect::Rect;
-use sdl2::render::{TextureCreator, WindowCanvas};
+use sdl2::render::TextureCreator;
 use sdl2::video::WindowContext;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -45,7 +45,7 @@ pub fn load_market<'a>(
         tile_vec.push(sub_vec);
     }
 
-    let mut pop = population::Population::new(tile_vec);
+    let pop = population::Population::new(tile_vec);
     let mut market_item_vec = Vec::new();
     let mut market_file = File::open("src/market_data.txt").expect("Can't open save market_file");
     let mut market_contents = String::new();
@@ -56,7 +56,7 @@ pub fn load_market<'a>(
     print!("{}", market_contents);
     for line in market_contents.lines() {
         let results: Vec<&str> = line.split(";").collect();
-        if (results[0] == "item") {
+        if results[0] == "item" {
             market_item_vec.push(item::Item::new(
                 Rect::new(
                     results[1].parse::<i32>().unwrap(),
@@ -125,7 +125,7 @@ pub fn load_home<'a>(
         print!("{}", home_contents);
         for line in home_contents.lines() {
             let results: Vec<&str> = line.split(";").collect();
-            if (results[0] == "item") {
+            if results[0] == "item" {
                 home_item_vec.push(item::Item::new(
                     Rect::new(
                         results[1].parse::<i32>().unwrap(),
@@ -137,7 +137,7 @@ pub fn load_home<'a>(
                     results[5].parse().unwrap(),
                     results[6].parse::<bool>().unwrap(),
                 ));
-            } else if (results[0] == "crop") {
+            } else if results[0] == "crop" {
                 let _x = results[1].parse::<i32>().unwrap();
                 let _y = results[2].parse::<i32>().unwrap();
                 pop.get_vec_mut()
@@ -174,7 +174,7 @@ pub fn save_home(pop: population::Population, item_vec: Vec<item::Item>) {
         Ok(file_to_save) => file_to_save,
     };
     for item in item_vec {
-        let mut output = "item;".to_owned()
+        let output = "item;".to_owned()
             + &item.x().to_string()
             + ";"
             + &item.y().to_string()

--- a/src/save_load.rs
+++ b/src/save_load.rs
@@ -13,7 +13,7 @@ pub fn load_market<'a>(
     for x in 0..((BG_W / TILE_SIZE) as i32) + 1 {
         let mut sub_vec = Vec::new();
         for y in 0..((BG_H / TILE_SIZE) as i32) + 1 {
-            sub_vec.push(population::Crop_Tile::new(
+            sub_vec.push(population::CropTile::new(
                 tile::Tile::new(
                     Rect::new(
                         (TILE_SIZE as i32) * x,
@@ -80,7 +80,7 @@ pub fn load_home<'a>(
     for x in 0..((BG_W / TILE_SIZE) as i32) + 1 {
         let mut sub_vec = Vec::new();
         for y in 0..((BG_H / TILE_SIZE) as i32) + 1 {
-            sub_vec.push(population::Crop_Tile::new(
+            sub_vec.push(population::CropTile::new(
                 tile::Tile::new(
                     Rect::new(
                         (TILE_SIZE as i32) * x,
@@ -145,7 +145,7 @@ pub fn load_home<'a>(
                     .unwrap()
                     .get_mut(_y as usize)
                     .unwrap()
-                    .setCrop(crop::Crop::from_save_string(
+                    .set_crop(crop::Crop::from_save_string(
                         &results,
                         texture_creator
                             .load_texture("src/images/Crop_Tileset.png")

--- a/src/sleep_menu.rs
+++ b/src/sleep_menu.rs
@@ -5,20 +5,16 @@ use crate::BG_H;
 use crate::BG_W;
 use crate::TILE_SIZE;
 
-use sdl2::event::Event;
 use sdl2::image::LoadTexture;
 use sdl2::keyboard::Keycode;
-use sdl2::mouse::MouseButton;
+
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
-use sdl2::render::BlendMode;
-use sdl2::render::Texture;
-use sdl2::render::TextureCreator;
+
 use sdl2::render::WindowCanvas;
 use std::collections::HashSet;
 use std::thread;
 use std::time::Duration;
-use std::time::Instant;
 
 pub fn start_sleep_menu(
     mut in_menu: Option<Menu>,

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,16 +1,10 @@
-use crate::crop::Crop;
-use crate::crop::CropType;
-use crate::genes::Genes;
-use crate::item::Item;
 use sdl2::image::LoadTexture;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
-use sdl2::render::Texture;
-use sdl2::render::TextureCreator;
+
 use sdl2::render::WindowCanvas;
 
 use crate::market_item::Market_item;
-use crate::player::Player;
 
 pub struct Store<'a> {
     item_selected: i32,
@@ -50,7 +44,7 @@ impl<'a> Store<'a> {
     }
 
     pub fn draw(&self, wincan: &mut WindowCanvas) {
-        let item_Rect = Rect::new(150, 30, 500, 580);
+        let _item_Rect = Rect::new(150, 30, 500, 580);
 
         //draw menu canvas
         wincan.set_draw_color(Color::RGBA(159, 82, 30, 255));

--- a/src/store.rs
+++ b/src/store.rs
@@ -4,7 +4,7 @@ use sdl2::rect::Rect;
 
 use sdl2::render::WindowCanvas;
 
-use crate::market_item::Market_item;
+use crate::market_item::MarketItem;
 
 pub struct Store<'a> {
     item_selected: i32,
@@ -12,89 +12,97 @@ pub struct Store<'a> {
     price: i32,
     sub_menu: i32,
     number_of_goods: i32,
-    item_Rect: Rect,
-    money_Rect: Rect,
-    amount_Rect: Rect,
-    menu_Rect: Rect,
-    items_array: &'a mut Vec<Market_item>,
+    item_rect: Rect,
+    money_rect: Rect,
+    amount_rect: Rect,
+    menu_rect: Rect,
+    items_array: &'a mut Vec<MarketItem>,
 }
 
 impl<'a> Store<'a> {
-    pub fn new(number_of_goods: i32, items_array: &'a mut Vec<Market_item>) -> Store<'a> {
+    pub fn new(number_of_goods: i32, items_array: &'a mut Vec<MarketItem>) -> Store<'a> {
         let item_selected = 0;
         let amount_selected = 1;
         let price = 1;
         let sub_menu = 0;
-        let item_Rect = Rect::new(150, 30, 500, 580);
-        let money_Rect = Rect::new(660, 570, 470, 40);
-        let amount_Rect = Rect::new(660, 510, 470, 40);
-        let menu_Rect = Rect::new(150, 30, 500, 580);
+        let item_rect = Rect::new(150, 30, 500, 580);
+        let money_rect = Rect::new(660, 570, 470, 40);
+        let amount_rect = Rect::new(660, 510, 470, 40);
+        let menu_rect = Rect::new(150, 30, 500, 580);
         Store {
             item_selected,
             amount_selected,
             price,
             sub_menu,
             number_of_goods,
-            item_Rect,
-            money_Rect,
-            amount_Rect,
-            menu_Rect,
+            item_rect,
+            money_rect,
+            amount_rect,
+            menu_rect,
             items_array,
         }
     }
 
     pub fn draw(&self, wincan: &mut WindowCanvas) {
-        let _item_Rect = Rect::new(150, 30, 500, 580);
+        let _item_rect = Rect::new(150, 30, 500, 580);
 
         //draw menu canvas
         wincan.set_draw_color(Color::RGBA(159, 82, 30, 255));
-        wincan.fill_rect(Rect::new(140, 20, 1000, 600));
+        wincan.fill_rect(Rect::new(140, 20, 1000, 600)).unwrap();
 
         // draw menu features
         wincan.set_draw_color(Color::RGBA(244, 182, 110, 255));
         // items
-        wincan.fill_rect(Rect::new(150, 30, 500, 580));
+        wincan.fill_rect(Rect::new(150, 30, 500, 580)).unwrap();
         // image
-        wincan.fill_rect(Rect::new(660, 30, 470, 470));
+        wincan.fill_rect(Rect::new(660, 30, 470, 470)).unwrap();
         // amount and price
-        wincan.fill_rect(Rect::new(660, 510, 470, 100));
+        wincan.fill_rect(Rect::new(660, 510, 470, 100)).unwrap();
 
         // draw item labels
         Store::item_list_draw(wincan, self.items_array);
 
         // selection
         wincan.set_draw_color(Color::RGBA(255, 0, 0, 60));
-        wincan.fill_rect(Rect::new(150, 30 + self.item_selected * 50, 500, 50));
+        wincan
+            .fill_rect(Rect::new(150, 30 + self.item_selected * 50, 500, 50))
+            .unwrap();
 
         // submenu
         wincan.set_draw_color(Color::RGBA(0, 0, 0, 40));
-        wincan.fill_rect(self.menu_Rect);
+        wincan.fill_rect(self.menu_rect).unwrap();
         Store::price_draw(wincan, 6, 665, 578, self.price);
         Store::price_draw(wincan, 6, 665, 518, self.amount_selected);
 
         let texture_creator = wincan.texture_creator();
-        let Lable_Texture = texture_creator
+        let label_texture = texture_creator
             .load_texture("src/images/MoneyLabels.png")
             .unwrap();
-        wincan.copy(
-            &Lable_Texture,
-            Rect::new(0, 0, 16, 5),
-            Rect::new(850, 578, 80, 25),
-        );
-        wincan.copy(
-            &Lable_Texture,
-            Rect::new(18, 0, 20, 5),
-            Rect::new(850, 518, 100, 25),
-        );
+        wincan
+            .copy(
+                &label_texture,
+                Rect::new(0, 0, 16, 5),
+                Rect::new(850, 578, 80, 25),
+            )
+            .unwrap();
+        wincan
+            .copy(
+                &label_texture,
+                Rect::new(18, 0, 20, 5),
+                Rect::new(850, 518, 100, 25),
+            )
+            .unwrap();
 
         let item_textures = texture_creator
             .load_texture("src/images/Crop_Tileset.png")
             .unwrap();
-        wincan.copy(
-            &item_textures,
-            self.items_array[self.item_selected as usize].pos,
-            Rect::new(665, 35, 460, 460),
-        );
+        wincan
+            .copy(
+                &item_textures,
+                self.items_array[self.item_selected as usize].pos,
+                Rect::new(665, 35, 460, 460),
+            )
+            .unwrap();
     }
 
     pub fn navigate(&mut self, increment: i32) {
@@ -142,13 +150,13 @@ impl<'a> Store<'a> {
             self.sub_menu = self.sub_menu + increment;
         }
         if self.sub_menu == 0 {
-            self.menu_Rect = self.item_Rect;
+            self.menu_rect = self.item_rect;
         }
         if self.sub_menu == 1 {
-            self.menu_Rect = self.amount_Rect;
+            self.menu_rect = self.amount_rect;
         }
         if self.sub_menu == 2 {
-            self.menu_Rect = self.money_Rect;
+            self.menu_rect = self.money_rect;
         }
     }
 
@@ -178,28 +186,32 @@ impl<'a> Store<'a> {
                 tailing_zero = true;
             }
 
-            wincan.copy(
-                &values_texture,
-                Rect::new(5 * modulo, 0, 5, 5),
-                Rect::new((initx + (initsteps - steps) * 25) as i32, inity, 25, 25),
-            );
+            wincan
+                .copy(
+                    &values_texture,
+                    Rect::new(5 * modulo, 0, 5, 5),
+                    Rect::new((initx + (initsteps - steps) * 25) as i32, inity, 25, 25),
+                )
+                .unwrap();
 
             steps = steps - 1;
         }
     }
 
-    pub fn item_list_draw(wincan: &mut WindowCanvas, items_array: &[Market_item]) {
+    pub fn item_list_draw(wincan: &mut WindowCanvas, items_array: &[MarketItem]) {
         let texture_creator = wincan.texture_creator();
         let market_menu_items = texture_creator
             .load_texture("src/images/Market_menu_items.png")
             .unwrap();
         let mut i = 0;
         for item in items_array {
-            wincan.copy(
-                &market_menu_items,
-                Rect::new(0, item.item_label_offset, 100, 6),
-                Rect::new(150, 30 + i * 50, 500, 50),
-            );
+            wincan
+                .copy(
+                    &market_menu_items,
+                    Rect::new(0, item.item_label_offset, 100, 6),
+                    Rect::new(150, 30 + i * 50, 500, 50),
+                )
+                .unwrap();
             Store::price_draw(wincan, 3, 380, 45 + i * 50, item.amount);
             Store::price_draw(wincan, 3, 530, 45 + i * 50, item.price);
             i = i + 1;

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1,23 +1,23 @@
 use crate::crop::CropType;
 use crate::genes;
-use crate::inventory_item_trait;
 use crate::population::Population;
+use crate::InventoryItemTrait;
 use sdl2::rect::Rect;
 use sdl2::render::Texture;
 
 /// This class is for tool functionality
 /// Right now, just have 3 tools
 
-pub enum tool_type {
-    hand,
-    hoe,
-    watering_can,
+pub enum ToolType {
+    Hand,
+    Hoe,
+    WateringCan,
 }
 
 pub struct Tool<'a> {
     src: Rect,
     texture: Texture<'a>,
-    current_type: tool_type,
+    current_type: ToolType,
 }
 
 impl<'a> Tool<'a> {
@@ -26,7 +26,7 @@ impl<'a> Tool<'a> {
     /// # Arguments
     /// * `pos` - Position of the player.
     /// * `texture` - Sprite sheet texture
-    pub fn new(src: Rect, texture: Texture<'a>, t: tool_type) -> Tool<'a> {
+    pub fn new(src: Rect, texture: Texture<'a>, t: ToolType) -> Tool<'a> {
         Tool {
             src,
             texture,
@@ -35,7 +35,7 @@ impl<'a> Tool<'a> {
     }
 }
 
-impl inventory_item_trait for Tool<'_> {
+impl InventoryItemTrait for Tool<'_> {
     fn get_value(&self) -> i32 {
         1
     }
@@ -54,7 +54,7 @@ impl inventory_item_trait for Tool<'_> {
 
         match self.current_type {
             // Hand
-            tool_type::hand => {
+            ToolType::Hand => {
                 // TODO remove debugging that prints genes
                 if let Some(_i) = pop
                     .get_crop_with_index(x as u32, y as u32)
@@ -90,7 +90,7 @@ impl inventory_item_trait for Tool<'_> {
                 }
             }
             // Hoe
-            tool_type::hoe => {
+            ToolType::Hoe => {
                 // If tile is empty, set as tilled dirt
                 if pop
                     .get_crop_with_index(x as u32, y as u32)
@@ -104,7 +104,7 @@ impl inventory_item_trait for Tool<'_> {
                 }
             }
             // Watering can
-            tool_type::watering_can => {
+            ToolType::WateringCan => {
                 if !pop.get_crop_with_index(x as u32, y as u32).get_watered() {
                     pop.get_crop_with_index_mut(x as u32, y as u32)
                         .set_water(true);


### PR DESCRIPTION
These changes bring us to zero warnings, albeit using some explicit "don't complain about this being unused" macros.

This also turns non-standard style (e.g. using camelCase for things that aren't types, or snake_case for things that are) and unnecessary parentheses from warnings to errors.

The CI script will complain if running `cargo fmt` would change any code style. Again, we're free to ignore this as is convenient. It'll show up as a separate "check" when it runs, so if the code compiles and passes tests but needs formatting, the PR will say something like "1 of 2 checks passed."