### PR TITLE
Optimized crop and tile textures

### DIFF
--- a/src/crop.rs
+++ b/src/crop.rs
@@ -34,7 +34,7 @@ pub struct Crop<'a> {
     /// appropriate tile.
     src: Rect,
     /// Texture of sprite sheet.
-    texture: Texture<'a>,
+    texture: &'a Texture<'a>,
     /// Boolean to hold whether plant has been
     /// watered or not.
     watered: bool,
@@ -61,7 +61,7 @@ impl<'a> Crop<'a> {
     pub fn new(
         pos: Rect,
         stage: u8,
-        texture: Texture<'a>,
+        texture: &'a Texture<'a>,
         watered: bool,
         t: CropType,
         genes: Option<genes::Genes>,
@@ -285,7 +285,7 @@ impl<'a> Crop<'a> {
     }
 
     /// Load a crop from a save string
-    pub fn from_save_string(s: &Vec<&str>, t: Texture<'a>) -> Crop<'a> {
+    pub fn from_save_string(s: &Vec<&str>, t: &'a Texture<'a>) -> Crop<'a> {
         let g;
         // println!("Loading from {:?}, len = {:?}", s, s.len());
         // TODO add to this as more genes are added or make from_save_string in Genes

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,8 +104,14 @@ fn main() {
     wincan.set_draw_color(Color::RGBA(255, 255, 255, 255));
     wincan.clear();
 
-    let _crop_texture = texture_creator
+    // Crop and tile textures; all use the same one, so
+    // just reference it for efficiency
+    let crop_texture = texture_creator
         .load_texture("src/images/Crop_Tileset.png")
+        .unwrap();
+
+    let tile_texture = texture_creator
+        .load_texture("src/images/Background_Tileset.png")
         .unwrap();
 
     // Roll group credits
@@ -187,17 +193,17 @@ fn main() {
 
     // LOAD SAVE DATA
     // Load home area
-    let home_tup = save_load::load_home(&texture_creator);
+    let home_tup = save_load::load_home(&texture_creator, &crop_texture, &tile_texture);
     let mut pop = home_tup.0;
     let item_vec = home_tup.1;
 
     // Load market
-    let market_tup = save_load::load_market(&texture_creator);
+    let market_tup = save_load::load_market(&texture_creator, &crop_texture, &tile_texture);
     let m_pop = market_tup.0;
     let m_item_vec = market_tup.1;
 
     // Load inventory
-    save_load::load_inventory(p.get_inventory(), &texture_creator);
+    save_load::load_inventory(p.get_inventory(), &crop_texture);
 
     // create a store with temp items
     let _seed_textures = texture_creator
@@ -276,9 +282,7 @@ fn main() {
                                     let mut grown_crop = crop::Crop::new(
                                         Rect::new(0, 0, 0, 0),
                                         3,
-                                        texture_creator
-                                            .load_texture("src/images/Crop_Tileset.png")
-                                            .unwrap(),
+                                        &crop_texture,
                                         false,
                                         t,
                                         Some(g.clone()),
@@ -290,9 +294,7 @@ fn main() {
                                         let new_crop = crop::Crop::new(
                                             Rect::new(0, 0, 0, 0),
                                             0,
-                                            texture_creator
-                                                .load_texture("src/images/Crop_Tileset.png")
-                                                .unwrap(),
+                                            &crop_texture,
                                             false,
                                             t,
                                             Some(g.clone()),
@@ -398,9 +400,7 @@ fn main() {
                             let _c = crop::Crop::new(
                                 Rect::new(0, 0, 0, 0),
                                 0,
-                                texture_creator
-                                    .load_texture("src/images/Crop_Tileset.png")
-                                    .unwrap(),
+                                &crop_texture,
                                 false,
                                 t,
                                 Some(genes::Genes::new()),

--- a/src/save_load.rs
+++ b/src/save_load.rs
@@ -1,13 +1,15 @@
 use crate::{crop, inventory, item, population, tile, BG_H, BG_W, TILE_SIZE};
 use sdl2::image::LoadTexture;
 use sdl2::rect::Rect;
-use sdl2::render::TextureCreator;
+use sdl2::render::{Texture, TextureCreator};
 use sdl2::video::WindowContext;
 use std::fs::File;
 use std::io::{Read, Write};
 
 pub fn load_market<'a>(
     texture_creator: &'a TextureCreator<WindowContext>,
+    crop_texture: &'a Texture<'a>,
+    tile_texture: &'a Texture<'a>,
 ) -> (population::Population<'a>, Vec<item::Item<'a>>) {
     let mut tile_vec = Vec::new();
     for x in 0..((BG_W / TILE_SIZE) as i32) + 1 {
@@ -21,9 +23,7 @@ pub fn load_market<'a>(
                         TILE_SIZE,
                         TILE_SIZE,
                     ),
-                    texture_creator
-                        .load_texture("src/images/Background_Tileset.png")
-                        .unwrap(),
+                    tile_texture,
                 ),
                 crop::Crop::new(
                     Rect::new(
@@ -33,9 +33,7 @@ pub fn load_market<'a>(
                         TILE_SIZE,
                     ),
                     0,
-                    texture_creator
-                        .load_texture("src/images/Crop_Tileset.png")
-                        .unwrap(),
+                    crop_texture,
                     false,
                     crop::CropType::None,
                     None,
@@ -75,6 +73,8 @@ pub fn load_market<'a>(
 
 pub fn load_home<'a>(
     texture_creator: &'a TextureCreator<WindowContext>,
+    crop_texture: &'a Texture<'a>,
+    tile_texture: &'a Texture<'a>,
 ) -> (population::Population<'a>, Vec<item::Item<'a>>) {
     let mut tile_vec = Vec::new();
     for x in 0..((BG_W / TILE_SIZE) as i32) + 1 {
@@ -88,9 +88,7 @@ pub fn load_home<'a>(
                         TILE_SIZE,
                         TILE_SIZE,
                     ),
-                    texture_creator
-                        .load_texture("src/images/Background_Tileset.png")
-                        .unwrap(),
+                    tile_texture,
                 ),
                 crop::Crop::new(
                     Rect::new(
@@ -100,9 +98,7 @@ pub fn load_home<'a>(
                         TILE_SIZE,
                     ),
                     0,
-                    texture_creator
-                        .load_texture("src/images/Crop_Tileset.png")
-                        .unwrap(),
+                    crop_texture,
                     false,
                     crop::CropType::None,
                     None,
@@ -145,12 +141,7 @@ pub fn load_home<'a>(
                     .unwrap()
                     .get_mut(_y as usize)
                     .unwrap()
-                    .set_crop(crop::Crop::from_save_string(
-                        &results,
-                        texture_creator
-                            .load_texture("src/images/Crop_Tileset.png")
-                            .unwrap(),
-                    ));
+                    .set_crop(crop::Crop::from_save_string(&results, crop_texture));
                 // If crop is present, set tile as tilled
                 if results[5]
                     .parse::<std::string::String>()
@@ -237,10 +228,7 @@ pub fn save_inventory(inventory: &inventory::Inventory) {
     }
 }
 
-pub fn load_inventory<'a>(
-    inventory: &mut inventory::Inventory<'a>,
-    texture_creator: &'a TextureCreator<WindowContext>,
-) {
+pub fn load_inventory<'a>(inventory: &mut inventory::Inventory<'a>, crop_texture: &'a Texture<'a>) {
     let mut inventory_file =
         File::open("saves/inventory_data.txt").expect("Can't open inventory_data.txt");
     let mut contents = String::new();
@@ -250,12 +238,7 @@ pub fn load_inventory<'a>(
     for line in contents.lines() {
         let results: Vec<&str> = line.split(";").collect();
         if results[0] == "crop" {
-            inventory.add_item(crop::Crop::from_save_string(
-                &results,
-                texture_creator
-                    .load_texture("src/images/Crop_Tileset.png")
-                    .unwrap(),
-            ));
+            inventory.add_item(crop::Crop::from_save_string(&results, crop_texture));
         }
     }
 }

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -6,12 +6,12 @@ use crate::TILE_SIZE;
 pub struct Tile<'a> {
     pos: Rect,
     src: Rect,
-    texture: Texture<'a>,
+    texture: &'a Texture<'a>,
     tilled: bool,
 }
 
 impl<'a> Tile<'a> {
-    pub fn new(pos: Rect, texture: Texture<'a>) -> Tile {
+    pub fn new(pos: Rect, texture: &'a Texture<'a>) -> Tile {
         let src = Rect::new(0, 0, TILE_SIZE, TILE_SIZE);
         Tile {
             pos,


### PR DESCRIPTION
Crops and tile backgrounds now use a reference to a single texture instance rather than each loading a whole texture, greatly reducing initial load time and RAM requirement.